### PR TITLE
Validating arguments are correct per spec

### DIFF
--- a/test/fixtures/no-spread/actual.js
+++ b/test/fixtures/no-spread/actual.js
@@ -1,0 +1,3 @@
+function failsParse() {
+  return import(...[1]);
+}

--- a/test/fixtures/no-spread/expected.json
+++ b/test/fixtures/no-spread/expected.json
@@ -1,0 +1,3 @@
+{
+  "error": "... is not allowed in import() (2:16)"
+}

--- a/test/fixtures/one-argument/actual.js
+++ b/test/fixtures/one-argument/actual.js
@@ -1,0 +1,3 @@
+function failsParse() {
+  return import('first', 'second');
+}

--- a/test/fixtures/one-argument/expected.json
+++ b/test/fixtures/one-argument/expected.json
@@ -1,0 +1,3 @@
+{
+  "error": "import() requires exactly one argument (2:9)"
+}


### PR DESCRIPTION
@jdalton This introduces the same argument validation that exists in Babylon.

Fixes #7