### PR TITLE
Adds walk support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.idea/
 node_modules/
 lib/

--- a/README.md
+++ b/README.md
@@ -28,6 +28,24 @@ const ast = acorn.parse(code, {
 });
 ```
 
+To use the updated walk functionality the process is similar. You can require the default implementation as:
+
+```js
+import walk from 'acorn-dynamic-import/lib/walk';
+// or...
+const dynamicImportWalk = require('acorn-dynamic-import/lib/walk').default;
+```
+
+Or you can use the injectable version for injecting the new walk functionality into your own version of Acorn like this:
+
+```js
+import { inject } from 'acorn-dynamic-import/lib/walk';
+import acornWalk from 'acorn/dist/walk';
+
+const walk = inject(acornWalk);
+
+``` 
+
 ## License
 
 This plugin is issued under the [MIT license](./LICENSE).

--- a/src/inject.js
+++ b/src/inject.js
@@ -1,5 +1,7 @@
 /* eslint-disable no-underscore-dangle */
 
+export const DynamicImportKey = 'Import';
+
 export default function injectDynamicImport(acorn) {
   const tt = acorn.tokTypes;
 
@@ -12,7 +14,7 @@ export default function injectDynamicImport(acorn) {
     if (this.type !== tt.parenL) {
       this.unexpected();
     }
-    return this.finishNode(node, 'Import');
+    return this.finishNode(node, DynamicImportKey);
   }
 
   function peekNext() {

--- a/src/walk.js
+++ b/src/walk.js
@@ -1,0 +1,12 @@
+import * as walk from 'acorn/dist/walk';
+import { DynamicImportKey } from './inject';
+
+export function inject(injectableWalk) {
+  return Object.assign({}, injectableWalk, {
+    base: Object.assign({}, injectableWalk.base, {
+      [DynamicImportKey]() {},
+    }),
+  });
+}
+
+export default inject(walk);


### PR DESCRIPTION
Since the provided `Import` node doesn't have any meta data, I just copied the implementation of the other import nodes from the base implementation of acorn [here](https://github.com/ternjs/acorn/blob/191bd45a526b70c0beaf855f2773cb5c05969345/src/walk/index.js#L349), which essentially just ignores the node. 

This commit resolves #9 