### PR TITLE
Whitelist "/lib" directory when publishing NPM module

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "acorn-dynamic-import",
   "description": "Support dynamic imports in acorn",
   "main": "lib/index.js",
+  "files": [
+    "/lib"
+  ],
   "homepage": "https://github.com/kesne/acorn-dynamic-import",
   "author": "Jordan Gensler <jordangens@gmail.com>",
   "repository": {


### PR DESCRIPTION
Hi @kesne,

Thanks for your work with this library.

I noticed that the `src` folder is being published to NPM:
![image](https://user-images.githubusercontent.com/13087421/58371266-73ddde00-7f42-11e9-95af-25e27c473e05.png)

This PR fixes that by whitelisting the `/lib` directory.

Cheers